### PR TITLE
Vždy zobrazit popisek NOTY u tlačítka

### DIFF
--- a/pages/song/components/SongBox/SongBox.vue
+++ b/pages/song/components/SongBox/SongBox.vue
@@ -11,7 +11,7 @@
                             @click="topMode = topMode == 1 ? 0 : 1"
                         >
                             <i class="fas fa-file-alt"></i>
-                            <span class="d-none d-sm-inline">Noty</span>
+                            <span class="d-sm-inline">Noty</span>
                         </a>
                         <a
                             v-if="otherExternals.length"


### PR DESCRIPTION
Moc bych se přimlouval, aby byl u tlačítka na noty vždy zobrazený textový popisek. Chápu důvody šetření místa, ale bez popisku je extrémně obtížné odhadnout, k čemu ta ikonka souboru je. Ověřeno osobní zkušeností. Snažil jsem se někoho navigovat, kde ty noty najde, a když neviděl ten popisek, nemohl se zorientovat.